### PR TITLE
Failsafe override for moldStartPosition

### DIFF
--- a/source/Plugin.cs
+++ b/source/Plugin.cs
@@ -182,6 +182,19 @@ namespace YesFox
             // starting point has not been chosen, or was invalid
 
             GameObject[] validSpots = outsideAINodes.Where(outsideAINode => Vector3.Distance(outsideAINode.transform.position, shipPos) >= 40f).ToArray();
+            if (validSpots.Length < 1)
+            {
+                // custom level; try shrinking range
+                validSpots = outsideAINodes.Where(outsideAINode => Vector3.Distance(outsideAINode.transform.position, shipPos) >= 35f).ToArray();
+                if (validSpots.Length < 1)
+                {
+                    // level is just too small
+                    Plugin.logSource.LogInfo($"Level \"{__instance.currentLevel.PlanetName}\" has no AI nodes at a valid distance");
+                    __instance.currentLevel.moldSpreadIterations = 0;
+                    return;
+                }
+            }
+
             __instance.currentLevel.moldStartPosition = System.Array.IndexOf(outsideAINodes, validSpots[new System.Random(__instance.randomMapSeed + 2017).Next(validSpots.Length)]);
 
             Plugin.logSource.LogInfo($"Mold growth: Selected node #{__instance.currentLevel.moldStartPosition}: coords {outsideAINodes[__instance.currentLevel.moldStartPosition].transform.position}, dist {Vector3.Distance(outsideAINodes[__instance.currentLevel.moldStartPosition].transform.position, shipPos)}");


### PR DESCRIPTION
Vanilla's code for selecting `moldStartPosition` attempts to grab an AI node at least 40m away from the ship, but it is not foolproof, and sometimes weeds will grow directly beside (or even inside) the ship.

This added patch runs between the scene loading (when the "outside AI nodes" become available) and LoadNewLevelWait, which is what normally selects a starting point for the weeds. The vanilla code bails out early if a position is already saved, which allows this patch to work.

This code will prevent a starting point from being selected within 40m of the ship's final landing position. This change will apply retroactively to any existing save files with invalid starting points, replacing the previous spot with a new valid one.

If there are no AI nodes at least 40m away from the ship (not an issue in any vanilla levels), then the distance will be reduced to 35m, and if that still produces no results, weed growth will be completely reset on that moon.