### PR TITLE
Config setting to cap the number of iterations generated

### DIFF
--- a/source/Plugin.cs
+++ b/source/Plugin.cs
@@ -188,6 +188,7 @@ namespace YesFox
                     // level is just too small
                     Plugin.logSource.LogInfo($"Level \"{__instance.currentLevel.PlanetName}\" has no AI nodes at a valid distance");
                     __instance.currentLevel.moldSpreadIterations = 0;
+                    __instance.currentLevel.moldStartPosition = -1;
                     return;
                 }
             }

--- a/source/Plugin.cs
+++ b/source/Plugin.cs
@@ -30,6 +30,7 @@ namespace YesFox
         internal static ConfigEntry<bool> Shroud_AllMoons;
         internal static ConfigEntry<float> Shroud_SpawnChance_SameMoon;
         internal static ConfigEntry<float> Shroud_SpawnChance_OtherMoons;
+        internal static ConfigEntry<int> Shroud_MaximumIterations;
         internal static ConfigEntry<int> Fox_MinimumWeeds;
         internal static ConfigEntry<int> Fox_SpawnChance;
 
@@ -62,6 +63,7 @@ namespace YesFox
             Shroud_AllMoons = Config.Bind("Weed Spawning", "All Moons", false, "Should weeds be able to spawn on all moons excluding gordion?");
             Shroud_SpawnChance_SameMoon = Config.Bind("Weed Spawning", "Spawn Chance (Current Moon)", 8.5f, new ConfigDescription("What should the chance for them to initially spawn the moon you are routed to be? Weeds attempt to spawn on all moons when you go into orbit after each day.", new AcceptableValueRange<float>(0, 100)));
             Shroud_SpawnChance_OtherMoons = Config.Bind("Weed Spawning", "Spawn Chance (Other Moons)", 4f, new ConfigDescription("What should the chance for them to initially spawn on other moons be? Weeds attempt to spawn on all moons when you go into orbit after each day.", new AcceptableValueRange<float>(0, 100)));
+            Shroud_MaximumIterations = Config.Bind("Weed Spawning", "Maximum Iterations", 20, new ConfigDescription("How many days in a row are additional weeds allowed to grow on the same moon?", new AcceptableValueRange<int>(1, 20)));
 
             Fox_MinimumWeeds = Config.Bind("Fox Spawning", "Minimum Weeds", 31, "The minimum amount of weeds required to spawn");
             Fox_SpawnChance = Config.Bind("Fox Spawning", "Spawn Chance", -1, new ConfigDescription("What should the spawn chance be? If left as -1 then it will be the same as vanilla (a higher chance the more weeds there are)", new AcceptableValueRange<int>(-1, 100)));
@@ -116,8 +118,11 @@ namespace YesFox
 
                 if (__instance.levels[i].moldSpreadIterations > 0)
                 {
-                    __instance.levels[i].moldSpreadIterations++;
-                    Plugin.logSource.LogInfo($"Increasing level #{i} {__instance.levels[i].PlanetName} mold iterations by 1; risen to {__instance.levels[i].moldSpreadIterations}");
+                    if (__instance.levels[i].moldSpreadIterations < Plugin.Shroud_MaximumIterations.Value)
+                    {
+                        __instance.levels[i].moldSpreadIterations++;
+                        Plugin.logSource.LogInfo($"Increasing level #{i} {__instance.levels[i].PlanetName} mold iterations by 1; risen to {__instance.levels[i].moldSpreadIterations}");
+                    }
                     continue;
                 }
 
@@ -155,6 +160,12 @@ namespace YesFox
         {
             if (!__instance.IsServer || __instance.currentLevel.moldSpreadIterations < 1)
                 return;
+
+            // retroactively apply iteration cap to old save files
+            if (__instance.currentLevel.moldSpreadIterations > Plugin.Shroud_MaximumIterations.Value)
+            {
+                __instance.currentLevel.moldSpreadIterations = Plugin.Shroud_MaximumIterations.Value;
+            }
 
             GameObject[] outsideAINodes = GameObject.FindGameObjectsWithTag("OutsideAINode");
             if (outsideAINodes == null || outsideAINodes.Length < 1)


### PR DESCRIPTION
I've added a config setting that lets the host set a custom maximum iteration count for weed generation. This was a feature in SoberShip, so users migrating to YesFox in v64 should find this useful.

The host's chosen value will properly sync to clients automatically. A side effect of this behavior is that save file logic is _slightly_ modified; vanilla would increase the number of iterations on a particular level with no upper bound, and then the GenerateMold() function would enforce the iteration cap client-side. This approach instead caps the value that gets saved to file (and thus transmitted from server to clients via RPC)