### PR TITLE
Corrected logic for nesting in biggest weed patch

### DIFF
--- a/source/Plugin.cs
+++ b/source/Plugin.cs
@@ -410,10 +410,21 @@ namespace YesFox
             }
         }
 
+        [HarmonyPatch(typeof(BushWolfEnemy), "GetBiggestWeedPatch")]
+        [HarmonyPrefix]
+        public static void Pre_GetBiggestWeedPatch(ref Collider[] ___nearbyColliders)
+        {
+            MoldSpreadManager moldSpreadManager = Object.FindObjectOfType<MoldSpreadManager>();
+            if (moldSpreadManager?.generatedMold != null && (___nearbyColliders == null || moldSpreadManager.generatedMold.Count > ___nearbyColliders.Length))
+            {
+                ___nearbyColliders = new Collider[moldSpreadManager.generatedMold.Count];
+            }
+        }
+
         // Fixed aggressivePosition not being set if there isn't a MoldAttractionPoint
         [HarmonyPatch(typeof(BushWolfEnemy), "GetBiggestWeedPatch")]
         [HarmonyPostfix]
-        public static void GetBiggestWeedPatch(BushWolfEnemy __instance, bool __result)
+        public static void Post_GetBiggestWeedPatch(BushWolfEnemy __instance, bool __result)
         {
             if (__result && !GameObject.FindGameObjectWithTag("MoldAttractionPoint"))
             {

--- a/source/Plugin.cs
+++ b/source/Plugin.cs
@@ -414,8 +414,14 @@ namespace YesFox
         [HarmonyPrefix]
         public static void Pre_GetBiggestWeedPatch(ref Collider[] ___nearbyColliders)
         {
+            if (___nearbyColliders != null && ___nearbyColliders.Length > 10)
+                return;
+
             MoldSpreadManager moldSpreadManager = Object.FindObjectOfType<MoldSpreadManager>();
-            if (moldSpreadManager?.generatedMold != null && (___nearbyColliders == null || moldSpreadManager.generatedMold.Count > ___nearbyColliders.Length))
+            if (moldSpreadManager?.generatedMold == null)
+                return;
+
+            if (___nearbyColliders == null || moldSpreadManager.generatedMold.Count > ___nearbyColliders.Length)
             {
                 ___nearbyColliders = new Collider[moldSpreadManager.generatedMold.Count];
             }


### PR DESCRIPTION
The vanilla code for GetBiggestWeedPatch is limited to detecting a maximum of 10 spores around a single weed, but at higher iteration counts, it's not unlikely for clusters to grow significantly larger than this. This limit causes the fox to determine the first weed with 10 or more surrounding spores to be "the biggest patch," which can sometimes cause it to nest in areas that are visibly less congested than others.

By resizing the array to match `generatedMold.Count`, weeds will never be skipped over, and the surrounding spore count will always be accurate. The improvement is immediately apparent as the fox will now consistently nest in the thickest cluster of weeds.

The affected code only runs on the host and thus it would be server-sided.

I personally don't notice a performance impact from this change, and Unity forums posts suggest that it should have negligible effects. Worst case, I think this could at least be implemented as an "Expensive Weed Search" setting. Alternatively, the array size could be limited to a much larger value than vanilla, like 75 to 100, if having a size 300+ array (possible with vanilla's iteration limit) is a concern.