### PR TITLE
Starting position selection, attempt #2

### DIFF
--- a/source/Plugin.cs
+++ b/source/Plugin.cs
@@ -461,8 +461,12 @@ namespace YesFox
                 {
                     if (__instance.IsServer)
                     {
-                        // weed growth has succeeded at least one time for this planet
-                        ES3.Save($"YesFox_{StartOfRound.Instance.currentLevel.name}_Success", true, __instance.currentSaveFileName);
+                        if (!ES3.Load($"YesFox_{StartOfRound.Instance.currentLevel.name}_Success", __instance.currentSaveFileName, false))
+                        {
+                            // weed growth has succeeded at least one time for this planet
+                            ES3.Save($"YesFox_{StartOfRound.Instance.currentLevel.name}_Success", true, __instance.currentSaveFileName);
+                            Plugin.logSource.LogDebug($"Mold growth on \"{StartOfRound.Instance.currentLevel.PlanetName}\" succeeded for first time");
+                        }
                     }
                 }
                 else
@@ -494,7 +498,10 @@ namespace YesFox
                 return;
 
             foreach (SelectableLevel level in __instance.levels)
+            {
                 ES3.DeleteKey($"YesFox_{level.name}_Success", __instance.currentSaveFileName);
+                Plugin.logSource.LogDebug($"Reset mold growth success for \"{level.PlanetName}\" (ship reset)");
+            }
         }
         [HarmonyPatch(typeof(MoldSpreadManager), "CheckIfAllSporesDestroyed")]
         [HarmonyPostfix]
@@ -504,7 +511,10 @@ namespace YesFox
                 return;
 
             if (StartOfRound.Instance.currentLevel.moldSpreadIterations < 1)
+            {
                 ES3.DeleteKey($"YesFox_{StartOfRound.Instance.currentLevel.name}_Success", __instance.currentSaveFileName);
+                Plugin.logSource.LogDebug($"Reset mold growth success for \"{StartOfRound.Instance.currentLevel.PlanetName}\" (all spores destroyed)");
+            }
         }
     }
 }

--- a/source/Plugin.cs
+++ b/source/Plugin.cs
@@ -444,18 +444,16 @@ namespace YesFox
             }
         }
 
-        static int index = -1;
-
         // Fixes weeds resetting when they naturally fail to spawn
         [HarmonyPatch(typeof(MoldSpreadManager), "GenerateMold")]
         [HarmonyPrefix]
-        static void Pre_GenerateMold(MoldSpreadManager __instance)
+        static void Pre_GenerateMold(MoldSpreadManager __instance, ref int __state)
         {
-            index = StartOfRound.Instance.currentLevel.moldStartPosition;
+            __state = StartOfRound.Instance.currentLevel.moldStartPosition;
         }
         [HarmonyPatch(typeof(MoldSpreadManager), "GenerateMold")]
         [HarmonyPostfix]
-        static void Post_GenerateMold(MoldSpreadManager __instance, int iterations)
+        static void Post_GenerateMold(MoldSpreadManager __instance, int __state, int iterations)
         {
             if (__instance.iterationsThisDay < 1 && iterations > 0)
             {
@@ -465,7 +463,7 @@ namespace YesFox
                     StartOfRound.Instance.currentLevel.moldSpreadIterations = iterations;
                     // at exactly 1 iteration, player will have never had the opportunity to see the weeds before; picking a different spawn location might help
                     if (iterations > 1)
-                        StartOfRound.Instance.currentLevel.moldStartPosition = index;
+                        StartOfRound.Instance.currentLevel.moldStartPosition = __state;
                 }
             }
         }

--- a/source/Plugin.cs
+++ b/source/Plugin.cs
@@ -180,10 +180,10 @@ namespace YesFox
                 float shipDist = Vector3.Distance(outsideAINodes[__instance.currentLevel.moldStartPosition].transform.position, shipPos);
 
                 // spot chosen is already an acceptable distance from the ship
-                if (shipDist >= 40f)
+                if (shipDist >= 30f)
                     return;
 
-                Plugin.logSource.LogInfo($"Mold growth is starting from node #{__instance.currentLevel.moldStartPosition} which is too close to the ship ({shipDist} < 40)");
+                Plugin.logSource.LogInfo($"Mold growth is starting from node #{__instance.currentLevel.moldStartPosition} which is too close to the ship ({shipDist} < 30)");
             }
 
             // starting point has not been chosen, or was invalid
@@ -192,7 +192,7 @@ namespace YesFox
             if (validSpots.Length < 1)
             {
                 // custom level; try shrinking range
-                validSpots = outsideAINodes.Where(outsideAINode => Vector3.Distance(outsideAINode.transform.position, shipPos) >= 35f).ToArray();
+                validSpots = outsideAINodes.Where(outsideAINode => Vector3.Distance(outsideAINode.transform.position, shipPos) >= 30f).ToArray();
                 if (validSpots.Length < 1)
                 {
                     // level is just too small

--- a/source/Plugin.cs
+++ b/source/Plugin.cs
@@ -461,10 +461,10 @@ namespace YesFox
                 {
                     if (__instance.IsServer)
                     {
-                        if (!ES3.Load($"YesFox_{StartOfRound.Instance.currentLevel.name}_Success", __instance.currentSaveFileName, false))
+                        if (!ES3.Load($"YesFox_{StartOfRound.Instance.currentLevel.name}_Success", GameNetworkManager.Instance.currentSaveFileName, false))
                         {
                             // weed growth has succeeded at least one time for this planet
-                            ES3.Save($"YesFox_{StartOfRound.Instance.currentLevel.name}_Success", true, __instance.currentSaveFileName);
+                            ES3.Save($"YesFox_{StartOfRound.Instance.currentLevel.name}_Success", true, GameNetworkManager.Instance.currentSaveFileName);
                             Plugin.logSource.LogDebug($"Mold growth on \"{StartOfRound.Instance.currentLevel.PlanetName}\" succeeded for first time");
                         }
                     }
@@ -475,7 +475,7 @@ namespace YesFox
                     if (__instance.IsServer)
                     {
                         // restore the previous values so weeds won't reset their growth cycle or change origin
-                        if (ES3.Load($"YesFox_{StartOfRound.Instance.currentLevel.name}_Success", __instance.currentSaveFileName, false))
+                        if (ES3.Load($"YesFox_{StartOfRound.Instance.currentLevel.name}_Success", GameNetworkManager.Instance.currentSaveFileName, false))
                         {
                             StartOfRound.Instance.currentLevel.moldSpreadIterations = iterations;
                             StartOfRound.Instance.currentLevel.moldStartPosition = __state;
@@ -499,7 +499,7 @@ namespace YesFox
 
             foreach (SelectableLevel level in __instance.levels)
             {
-                ES3.DeleteKey($"YesFox_{level.name}_Success", __instance.currentSaveFileName);
+                ES3.DeleteKey($"YesFox_{level.name}_Success", GameNetworkManager.Instance.currentSaveFileName);
                 Plugin.logSource.LogDebug($"Reset mold growth success for \"{level.PlanetName}\" (ship reset)");
             }
         }
@@ -512,7 +512,7 @@ namespace YesFox
 
             if (StartOfRound.Instance.currentLevel.moldSpreadIterations < 1)
             {
-                ES3.DeleteKey($"YesFox_{StartOfRound.Instance.currentLevel.name}_Success", __instance.currentSaveFileName);
+                ES3.DeleteKey($"YesFox_{StartOfRound.Instance.currentLevel.name}_Success", GameNetworkManager.Instance.currentSaveFileName);
                 Plugin.logSource.LogDebug($"Reset mold growth success for \"{StartOfRound.Instance.currentLevel.PlanetName}\" (all spores destroyed)");
             }
         }

--- a/source/Plugin.cs
+++ b/source/Plugin.cs
@@ -160,6 +160,13 @@ namespace YesFox
             if (!__instance.IsServer || __instance.currentLevel.moldSpreadIterations < 1)
                 return;
 
+            if (!__instance.currentLevel.canSpawnMold && !Plugin.Shroud_AllMoons.Value)
+            {
+                __instance.currentLevel.moldSpreadIterations = 0;
+                __instance.currentLevel.moldStartPosition = -1;
+                return;
+            }
+
             // retroactively apply iteration cap to old save files
             if (__instance.currentLevel.moldSpreadIterations > Plugin.Shroud_MaximumIterations.Value)
             {
@@ -456,6 +463,7 @@ namespace YesFox
                 if (__instance.IsServer)
                 {
                     StartOfRound.Instance.currentLevel.moldSpreadIterations = iterations;
+                    // at exactly 1 iteration, player will have never had the opportunity to see the weeds before; picking a different spawn location might help
                     if (iterations > 1)
                         StartOfRound.Instance.currentLevel.moldStartPosition = index;
                 }

--- a/source/Plugin.cs
+++ b/source/Plugin.cs
@@ -436,5 +436,30 @@ namespace YesFox
                 __instance.aggressivePosition = __instance.mostHiddenPosition;
             }
         }
+
+        static int index = -1;
+
+        // Fixes weeds resetting when they naturally fail to spawn
+        [HarmonyPatch(typeof(MoldSpreadManager), "GenerateMold")]
+        [HarmonyPrefix]
+        static void Pre_GenerateMold(MoldSpreadManager __instance)
+        {
+            index = StartOfRound.Instance.currentLevel.moldStartPosition;
+        }
+        [HarmonyPatch(typeof(MoldSpreadManager), "GenerateMold")]
+        [HarmonyPostfix]
+        static void Post_GenerateMold(MoldSpreadManager __instance, int iterations)
+        {
+            if (__instance.iterationsThisDay < 1 && iterations > 0)
+            {
+                Plugin.logSource.LogInfo($"Mold growth on \"{StartOfRound.Instance.currentLevel.PlanetName}\" erroneously reset from {iterations} iterations");
+                if (__instance.IsServer)
+                {
+                    StartOfRound.Instance.currentLevel.moldSpreadIterations = iterations;
+                    if (iterations > 1)
+                        StartOfRound.Instance.currentLevel.moldStartPosition = index;
+                }
+            }
+        }
     }
 }

--- a/source/YesFox.csproj
+++ b/source/YesFox.csproj
@@ -33,6 +33,9 @@
         <Reference Include="Assembly-CSharp" Publicize="true">
             <HintPath>$(LethalCompanyDir)Lethal Company_Data/Managed/Assembly-CSharp.dll</HintPath>
         </Reference>
+		<Reference Include="Assembly-CSharp-firstpass">
+			<HintPath>$(LethalCompanyDir)Lethal Company_Data/Managed/Assembly-CSharp-firstpass.dll</HintPath>
+		</Reference>
         <Reference Include="Unity.Netcode.Runtime">
             <HintPath>$(LethalCompanyDir)Lethal Company_Data/Managed/Unity.Netcode.Runtime.dll</HintPath>
         </Reference>

--- a/source/YesFox.csproj
+++ b/source/YesFox.csproj
@@ -33,9 +33,6 @@
         <Reference Include="Assembly-CSharp" Publicize="true">
             <HintPath>$(LethalCompanyDir)Lethal Company_Data/Managed/Assembly-CSharp.dll</HintPath>
         </Reference>
-		<Reference Include="Assembly-CSharp-firstpass">
-			<HintPath>$(LethalCompanyDir)Lethal Company_Data/Managed/Assembly-CSharp-firstpass.dll</HintPath>
-		</Reference>
         <Reference Include="Unity.Netcode.Runtime">
             <HintPath>$(LethalCompanyDir)Lethal Company_Data/Managed/Unity.Netcode.Runtime.dll</HintPath>
         </Reference>


### PR DESCRIPTION
My old code for selecting the starting position had a couple of flaws:

1. It wasn't weighted towards the ship like in the original code, which reduced the likelihood of the fox being present and actually threatening in the general playable space
2. There were no safeguards against invalid spawn points being selected, causing weeds to erroneously reset or softlock at low iteration counts where the fox couldn't spawn

Both of these issues have been thoroughly addressed in this newer, more robust system for spawn point selection. It has been extensively tested and results are promising - so far, I have not encountered any game-breaking issues, and I believe this is ready for a live release in its current state.

Since the new system is weighted towards spawning weeds closer to the ship, I have also exposed the minimum starting distance as a config setting, in case users find them to be too intrusive compared to previous versions.