### PR TITLE
Optimizations + Growth chance config setting

### DIFF
--- a/source/Plugin.cs
+++ b/source/Plugin.cs
@@ -112,7 +112,7 @@ namespace YesFox
             if (!__instance.IsOwner) return false;
 
             System.Random random = new System.Random(__instance.randomMapSeed + 32);
-            Terminal terminal = Object.FindFirstObjectByType<Terminal>();
+            Terminal terminal = Object.FindAnyObjectByType<Terminal>();
             for (int i = 0; i < __instance.levels.Length; i++)
             {
                 if (i == 3 || (!__instance.levels[i].canSpawnMold && !Plugin.Shroud_AllMoons.Value))
@@ -263,7 +263,7 @@ namespace YesFox
 
             try
             {
-                EnemyType bushWolfTypeOrig = Object.FindFirstObjectByType<QuickMenuManager>()?.testAllEnemiesLevel?.OutsideEnemies.FirstOrDefault(x => x.enemyType.name == "BushWolf" && x.enemyType.enemyPrefab?.GetComponentsInChildren<SkinnedMeshRenderer>()?.Length > 0)?.enemyType;
+                EnemyType bushWolfTypeOrig = Object.FindAnyObjectByType<QuickMenuManager>()?.testAllEnemiesLevel?.OutsideEnemies.FirstOrDefault(x => x.enemyType.name == "BushWolf" && x.enemyType.enemyPrefab?.GetComponentsInChildren<SkinnedMeshRenderer>()?.Length > 0)?.enemyType;
                 EnemyType bushWolfTypeAddon = Resources.FindObjectsOfTypeAll<EnemyType>().FirstOrDefault(x => x.name == "BushWolf" && x.enemyPrefab == Plugin.BushWolfAddonPrefab);
                 if (bushWolfTypeOrig != bushWolfTypeAddon)
                 {
@@ -320,7 +320,7 @@ namespace YesFox
 
         public static void SpawnWeedEnemies(int currentHour)
         {
-            MoldSpreadManager moldSpreadManager = Object.FindFirstObjectByType<MoldSpreadManager>();
+            MoldSpreadManager moldSpreadManager = Object.FindAnyObjectByType<MoldSpreadManager>();
             int num = 0;
             if (moldSpreadManager != null)
             {
@@ -453,7 +453,7 @@ namespace YesFox
             if (___nearbyColliders != null && ___nearbyColliders.Length > 10)
                 return;
 
-            MoldSpreadManager moldSpreadManager = Object.FindFirstObjectByType<MoldSpreadManager>();
+            MoldSpreadManager moldSpreadManager = Object.FindAnyObjectByType<MoldSpreadManager>();
             if (moldSpreadManager?.generatedMold == null)
                 return;
 

--- a/source/Plugin.cs
+++ b/source/Plugin.cs
@@ -28,6 +28,8 @@ namespace YesFox
         internal static ConfigEntry<bool> Shroud_AllMoons;
         internal static ConfigEntry<float> Shroud_SpawnChance_SameMoon;
         internal static ConfigEntry<float> Shroud_SpawnChance_OtherMoons;
+        internal static ConfigEntry<float> Shroud_GrowChance_SameMoon;
+        internal static ConfigEntry<float> Shroud_GrowChance_OtherMoons;
         internal static ConfigEntry<int> Shroud_MaximumIterations;
         internal static ConfigEntry<float> Shroud_MinimumDistance;
         internal static ConfigEntry<int> Fox_MinimumWeeds;
@@ -62,6 +64,8 @@ namespace YesFox
             Shroud_AllMoons = Config.Bind("Weed Spawning", "All Moons", false, "Should weeds be able to spawn on all moons excluding gordion?");
             Shroud_SpawnChance_SameMoon = Config.Bind("Weed Spawning", "Spawn Chance (Current Moon)", 8.5f, new ConfigDescription("What should the chance for them to initially spawn the moon you are routed to be? Weeds attempt to spawn on all moons when you go into orbit after each day.", new AcceptableValueRange<float>(0, 100)));
             Shroud_SpawnChance_OtherMoons = Config.Bind("Weed Spawning", "Spawn Chance (Other Moons)", 4f, new ConfigDescription("What should the chance for them to initially spawn on other moons be? Weeds attempt to spawn on all moons when you go into orbit after each day.", new AcceptableValueRange<float>(0, 100)));
+            Shroud_GrowChance_SameMoon = Config.Bind("Weed Spawning", "Growth Chance (Current Moon)", 100f, new ConfigDescription("What is the chance that weeds should grow another \"step\" after leaving a moon? This applies at the end of the day, only once the spawn chance has succeeded for the first time.", new AcceptableValueRange<float>(0, 100)));
+            Shroud_GrowChance_OtherMoons = Config.Bind("Weed Spawning", "Growth Chance (Other Moons)", 100f, new ConfigDescription("What is the chance that weeds should grow another \"step\" for all other moons? This applies at the end of the day, only once the spawn chance has succeeded for the first time.", new AcceptableValueRange<float>(0, 100)));
             Shroud_MaximumIterations = Config.Bind("Weed Spawning", "Maximum Iterations", 20, new ConfigDescription("How many days in a row are additional weeds allowed to grow on the same moon?", new AcceptableValueRange<int>(1, 20)));
             // absolute upper limit is 70.4927 (Experimentation's furthest valid distance at default settings)
             Shroud_MinimumDistance = Config.Bind("Weed Spawning", "Minimum Distance", 40f, new ConfigDescription("How many units away from the ship must the starting points for weed growth be?", new AcceptableValueRange<float>(30f, 70f)));
@@ -121,8 +125,12 @@ namespace YesFox
                 {
                     if (__instance.levels[i].moldSpreadIterations < Plugin.Shroud_MaximumIterations.Value)
                     {
-                        __instance.levels[i].moldSpreadIterations++;
-                        Plugin.logSource.LogInfo($"Increasing level #{i} {__instance.levels[i].PlanetName} mold iterations by 1; risen to {__instance.levels[i].moldSpreadIterations}");
+                        float chance = (__instance.levels[i] == __instance.currentLevel ? Plugin.Shroud_GrowChance_SameMoon.Value : Plugin.Shroud_GrowChance_OtherMoons.Value) / 100f;
+                        if (random.NextDouble() <= chance)
+                        {
+                            __instance.levels[i].moldSpreadIterations++;
+                            Plugin.logSource.LogInfo($"Increasing level #{i} {__instance.levels[i].PlanetName} mold iterations by 1; risen to {__instance.levels[i].moldSpreadIterations}");
+                        }
                     }
                     continue;
                 }


### PR DESCRIPTION
I added some new config settings to change the chance weeds will grow at the end of each day, as requested in the Discord thread

Optimizations:
- Use FindAnyObjectByType instead of FindFirstObjectByType (the latter is identical to FindObjectOfType, but the former doesn't sort and is faster if your behavior doesn't rely on sorted results)
- Cached MoldSpreadManager for all vanilla functions and YesFox patches. Pretty minor but this will reduce lag spikes when:
  - A spawn wave occurs (every 2 in-game hours)
  - The fox searches for the biggest patch of shrouds (GetBiggestWeedPatch, every 5-30 seconds)
  - Loading a new level, saving the game, etc.
- Cached VehicleController for BushWolfEnemy.Update, which caused _extreme_ persistent lag when the fox was grappling players
- Cached MoldAttractionPoint game object, which will reduce lag spikes during GetBiggestWeedPatch
  - Won't apply on Rend or Dine, since there is no game object to cache
- Cached MoldSpore game objects, which will also reduce lag spikes during GetBiggestWeedPatch