### PR TITLE
Fix WeedEnemies failing to populate when rehosting

### DIFF
--- a/source/Plugin.cs
+++ b/source/Plugin.cs
@@ -292,7 +292,7 @@ namespace YesFox
                         {
                             foreach (SkinnedMeshRenderer renderer in renderersNew)
                             {
-                                Material[] mats = new Material[renderer.sharedMaterials.Length];
+                                Material[] mats = new Material[renderer.name == "BodyLOD2" ? 1 : 2];
                                 for (int i = 0; i < mats.Length; i++)
                                 {
                                     mats[i] = rendererOrig.materials[i];


### PR DESCRIPTION
After the changes made in v1.1.1, WeedEnemies fails to populate the second+ time a lobby is hosted, unless the game is completely rebooted. This will completely prevent the kidnapper fox from spawning, due to `ListEmpty` in SpawnWeedEnemies

I cleaned up the logic here, so it's a lot simpler and now also works after any number of rehosts. I also fixed some materials on the body's LOD models while I was at it