### PR TITLE
Update SpawnWeedEnemies() to run closer to its original vanilla timing

### DIFF
--- a/source/Plugin.cs
+++ b/source/Plugin.cs
@@ -556,9 +556,9 @@ namespace YesFox
             WeedEnemySpawnRandom = new System.Random(__instance.playersManager.randomMapSeed + 42);
         }
 
-        [HarmonyPatch(typeof(RoundManager), "AdvanceHourAndSpawnNewBatchOfEnemies")]
-        [HarmonyPrefix]
-        public static void AdvanceHourAndSpawnNewBatchOfEnemies(RoundManager __instance)
+        [HarmonyPatch(typeof(RoundManager), "SpawnEnemiesOutside")]
+        [HarmonyPostfix]
+        public static void SpawnEnemiesOutside(RoundManager __instance)
         {
             if (GameNetworkManager.Instance.gameVersionNum >= 64)
             {


### PR DESCRIPTION
Before v64, `RoundManager.SpawnWeedEnemies()` ran immediately after `RoundManager.SpawnEnemiesOutside()` in `RoundManager.AdvanceHourAndSpawnNewBatchOfEnemies()`.

However, in YesFox, it runs in a prefix to `AdvanceHourAndSpawnNewBatchOfEnemies()` instead. This has a couple of negative side effects:

1. `RoundManager.currentHour` is not incremented until after `SpawnWeedEnemies()` has run. Both `SpawnWeedEnemies()` and `SpawnRandomWeedEnemy()` care about the value of `currentHour`, so the wrong value will be sampled from the probability curves in the current version.
2. Right now the kidnapper fox gets spawning priority over all other outside monsters, which is not consistent with vanilla's behavior.
   - For example, when landing on eclipsed Dine, 4 monsters get spawned outside immediately - at only 7 max power, and with all potential monsters taking up 2 power at minimum, it's likely for all of that power level to be immediately consumed by `SpawnEnemiesOutside()`. Afterwards, the fox is supposed to be blocked from spawning, as weed enemies use up outside power, none of which is left.
   - With YesFox's current behavior, the kidnapper fox is given the chance to spawn immediately, and then its power level will block some of the other outside monsters that should have spawned. This means even during eclipses, once weeds are at full growth, the kidnapper fox is basically guaranteed every day.
3. This is a personal bias of mine... I'm currently working on a mod to fix spawn wave timings, and right now the kidnapper fox is unable to spawn until 9 AM in the test version of that, since I'm shuffling around when `AdvanceHourAndSpawnNewBatchOfEnemies()` gets called. I call `SpawnEnemiesOutside()` when it is supposed to be called, but that's currently not enough to trigger YesFox's `SpawnWeedEnemies()`, and fixing this issue would also clear that up for me.