### PR TITLE
Fix wrong weed growth values getting written to level saves

### DIFF
--- a/source/Plugin.cs
+++ b/source/Plugin.cs
@@ -623,5 +623,59 @@ namespace YesFox
             //Plugin.Logger.LogWarning($"{__originalMethod.Name} transpiler failed");
             return codes;
         }
+
+        [HarmonyPatch(typeof(RoundManager), nameof(RoundManager.GenerateNewLevelClientRpc))]
+        [HarmonyPrefix]
+        static void Pre_GenerateNewLevelClientRpc(RoundManager __instance, int moldIterations, ref int moldStartPosition, ref object[] __state)
+        {
+            if (moldIterations < 1)
+            {
+                // vanilla defaults to 0, when it should be -1
+                if (moldStartPosition == 0)
+                    Plugin.logSource.LogDebug($"Spawn bug has been blocked on {__instance.currentLevel.name}");
+
+                moldStartPosition = -1;
+            }
+
+            // save some locals
+            __state =
+            [
+                __instance.currentLevel,
+                __instance.currentLevel.moldSpreadIterations,
+                __instance.currentLevel.moldStartPosition
+            ];
+        }
+
+        [HarmonyPatch(typeof(RoundManager), nameof(RoundManager.GenerateNewLevelClientRpc))]
+        [HarmonyPostfix]
+        static void Post_GenerateNewLevelClientRpc(RoundManager __instance, int moldIterations, ref int moldStartPosition, object[] __state)
+        {
+            SelectableLevel previousLevel = (SelectableLevel)__state[0];
+
+            if (!__instance.IsServer)
+                Plugin.logSource.LogDebug($"Landed on {__instance.currentLevel.name} - previous moon was {previousLevel.name}");
+
+            // when landing on the same moon twice in a row, there's no problem
+            if (__instance.currentLevel == previousLevel)
+                return;
+
+            int previousMoldSpreadIterations = (int)__state[1];
+            int previousMoldStartPosition = (int)__state[2];
+
+            if (previousLevel.moldSpreadIterations != previousMoldSpreadIterations || previousLevel.moldStartPosition != previousMoldStartPosition)
+            {
+                Plugin.logSource.LogDebug($"Data for {previousLevel.name} was erroneously overwritten: {previousMoldSpreadIterations} iterations at node #{previousMoldStartPosition} -> {previousLevel.moldSpreadIterations} iterations at node #{previousLevel.moldStartPosition}");
+
+                previousLevel.moldSpreadIterations = previousMoldSpreadIterations;
+                previousLevel.moldStartPosition = previousMoldStartPosition;
+
+                Plugin.logSource.LogDebug($"Restored original data for {previousLevel.name}");
+            }
+
+            __instance.currentLevel.moldSpreadIterations = moldIterations;
+            __instance.currentLevel.moldStartPosition = moldStartPosition;
+
+            Plugin.logSource.LogDebug($"Applied growth data properly to {__instance.currentLevel.name}");
+        }
     }
 }

--- a/source/Plugin.cs
+++ b/source/Plugin.cs
@@ -753,7 +753,7 @@ namespace YesFox
             {
                 // vanilla defaults to 0, when it should be -1
                 if (moldStartPosition == 0)
-                    Plugin.logSource.LogDebug($"Spawn bug has been blocked on {__instance.currentLevel.name}");
+                    Plugin.StaticLogger.LogDebug($"Spawn bug has been blocked on {__instance.currentLevel.name}");
 
                 moldStartPosition = -1;
             }
@@ -774,7 +774,7 @@ namespace YesFox
             SelectableLevel previousLevel = (SelectableLevel)__state[0];
 
             if (!__instance.IsServer)
-                Plugin.logSource.LogDebug($"Landed on {__instance.currentLevel.name} - previous moon was {previousLevel.name}");
+                Plugin.StaticLogger.LogDebug($"Landed on {__instance.currentLevel.name} - previous moon was {previousLevel.name}");
 
             // when landing on the same moon twice in a row, there's no problem
             if (__instance.currentLevel == previousLevel)
@@ -785,18 +785,18 @@ namespace YesFox
 
             if (previousLevel.moldSpreadIterations != previousMoldSpreadIterations || previousLevel.moldStartPosition != previousMoldStartPosition)
             {
-                Plugin.logSource.LogDebug($"Data for {previousLevel.name} was erroneously overwritten: {previousMoldSpreadIterations} iterations at node #{previousMoldStartPosition} -> {previousLevel.moldSpreadIterations} iterations at node #{previousLevel.moldStartPosition}");
+                Plugin.StaticLogger.LogDebug($"Data for {previousLevel.name} was erroneously overwritten: {previousMoldSpreadIterations} iterations at node #{previousMoldStartPosition} -> {previousLevel.moldSpreadIterations} iterations at node #{previousLevel.moldStartPosition}");
 
                 previousLevel.moldSpreadIterations = previousMoldSpreadIterations;
                 previousLevel.moldStartPosition = previousMoldStartPosition;
 
-                Plugin.logSource.LogDebug($"Restored original data for {previousLevel.name}");
+                Plugin.StaticLogger.LogDebug($"Restored original data for {previousLevel.name}");
             }
 
             __instance.currentLevel.moldSpreadIterations = moldIterations;
             __instance.currentLevel.moldStartPosition = moldStartPosition;
 
-            Plugin.logSource.LogDebug($"Applied growth data properly to {__instance.currentLevel.name}");
+            Plugin.StaticLogger.LogDebug($"Applied growth data properly to {__instance.currentLevel.name}");
         }
     }
 }


### PR DESCRIPTION
Fixed a couple of vanilla bugs with weed values getting set on `SelectableLevel`s:
1. `RoundManager.LoadNewLevelWait()` defaults to calling `RoundManager.GenerateNewLevelClientRpc()` with `moldSpreadIterations: 0` and `moldStartPosition: 0`, whenever `moldSpreadIterations` is 0 or less. However, whenever `moldSpreadIterations` is 0, `moldStartPosition` is intended to be **-1**, so that the algorithm for selecting a spawn point gets run once weeds start growing (the first time you land once `moldSpreadIterations` >= 1)
   - This caused vanilla's infamous bug with vain shrouds starting out immediately on the ship. Nodes are sorted by distance-to-ship, so index 0 literally meant "the node that is closest to the ship". This bug would occur any time you landed on a moon that hadn't been growing weeds yet, at which point that moon was effectively "cursed" to spawn weeds on the ship for the rest of that save file.
   - YesFox already has code for recognizing this situation and fixing it when it occurs, so it hasn't been a gameplay issue for a little while... but it never hurts to nip the source of the problem in the bud
2. Clients overwrite `moldSpreadIterations` and `moldStartPosition` for whatever level the ship was previously parked at, *not* the one that is currently being landed on.
   - As far as I know, this doesn't cause any actual issues right now, since the host's information is passed through the RPC and that's what actually gets used to spawn the weeds. But it's definitely not intended and there is some risk of this causing other, difficult-to-diagnose issues later down the line