### PR TITLE
AI adjustments for player count

### DIFF
--- a/source/Plugin.cs
+++ b/source/Plugin.cs
@@ -793,7 +793,7 @@ namespace YesFox
                     {
                         codes[i].opcode = OpCodes.Ldsfld;
                         codes[i].operand = AccessTools.Field(typeof(HarmonyPatches), nameof(vehicleController));
-                        Plugin.StaticLogger.LogDebug($"Use cached VehicleController in Kidnapper Fox AI");
+                        Plugin.StaticLogger.LogDebug("Use cached VehicleController in Kidnapper Fox AI");
                     }
                     else
                     {
@@ -803,13 +803,42 @@ namespace YesFox
                             codes[i].operand = mathfClamp;
                             codes.Insert(i, new(OpCodes.Ldc_I4_3));
                             i++;
-                            Plugin.StaticLogger.LogDebug($"Clamp livingPlayers-1 between 0 and 3");
+                            Plugin.StaticLogger.LogDebug("Clamp livingPlayers-1 between 0 and 3");
                         }
                     }
                 }
             }
 
             return codes;
+        }
+
+        [HarmonyPatch(typeof(BushWolfEnemy), nameof(BushWolfEnemy.DoAIInterval))]
+        [HarmonyPostfix]
+        static void BushWolfEnemy_Post_DoAIInterval(BushWolfEnemy __instance)
+        {
+            if (__instance.checkPlayer > 3)
+            {
+                // checkPlayer can only be 4+ when a mod has resized the player array
+                // very likely, players with resized lobbies will have empty slots leftover, which unnecessarily slows down the fox's target processing
+                
+                // 50 attempts to skip over empty player slots
+                for (int i = 0; i < 50; i++)
+                {
+                    // a player is connected in this slot
+                    if (__instance.checkPlayer < StartOfRound.Instance.allPlayerScripts.Length && StartOfRound.Instance.allPlayerScripts[__instance.checkPlayer] != null && (StartOfRound.Instance.allPlayerScripts[__instance.checkPlayer].isPlayerControlled || StartOfRound.Instance.allPlayerScripts[__instance.checkPlayer].isPlayerDead))
+                        return;
+
+                    // move to next slot
+                    __instance.checkPlayer++;
+
+                    // wraparound means we're done
+                    if (__instance.checkPlayer >= StartOfRound.Instance.allPlayerScripts.Length)
+                    {
+                        __instance.checkPlayer = 0;
+                        return;
+                    }
+                }
+            }
         }
     }
 }

--- a/source/Plugin.cs
+++ b/source/Plugin.cs
@@ -642,30 +642,6 @@ namespace YesFox
                 vehicleController = __instance;
         }
 
-        [HarmonyPatch(typeof(BushWolfEnemy), nameof(BushWolfEnemy.Update))]
-        [HarmonyTranspiler]
-        static IEnumerable<CodeInstruction> CacheVehicleController(IEnumerable<CodeInstruction> instructions)
-        {
-            List<CodeInstruction> codes = instructions.ToList();
-
-            for (int i = 0; i < codes.Count; i++)
-            {
-                if (codes[i].opcode == OpCodes.Call)
-                {
-                    string methodName = codes[i].operand.ToString();
-                    if (methodName.Contains("FindObjectOfType") && methodName.Contains("VehicleController"))
-                    {
-                        codes[i].opcode = OpCodes.Ldsfld;
-                        codes[i].operand = AccessTools.Field(typeof(HarmonyPatches), nameof(vehicleController));
-                        Plugin.StaticLogger.LogDebug($"Use cached VehicleController in Kidnapper Fox AI");
-                        break;
-                    }
-                }
-            }
-
-            return codes;
-        }
-
         static readonly MethodInfo MOLD_SPREAD_MANAGER_INSTANCE = AccessTools.DeclaredPropertyGetter(typeof(HarmonyPatches), nameof(MoldSpreadManager));
         [HarmonyPatch(typeof(GameNetworkManager), nameof(GameNetworkManager.SaveGameValues))]
         [HarmonyPatch(typeof(RoundManager), nameof(RoundManager.LoadNewLevelWait), MethodType.Enumerator)]
@@ -797,6 +773,43 @@ namespace YesFox
             __instance.currentLevel.moldStartPosition = moldStartPosition;
 
             Plugin.StaticLogger.LogDebug($"Applied growth data properly to {__instance.currentLevel.name}");
+        }
+
+        [HarmonyPatch(typeof(BushWolfEnemy), nameof(BushWolfEnemy.Update))]
+        [HarmonyTranspiler]
+        static IEnumerable<CodeInstruction> BushWolfEnemy_Trans_Update(IEnumerable<CodeInstruction> instructions)
+        {
+            List<CodeInstruction> codes = instructions.ToList();
+
+            MethodInfo mathfMax = AccessTools.Method(typeof(Mathf), nameof(Mathf.Max), [ typeof(int), typeof(int) ]);
+            MethodInfo mathfClamp = AccessTools.Method(typeof(Mathf), nameof(Mathf.Clamp), [ typeof(int), typeof(int), typeof(int) ]);
+            FieldInfo livingPlayers = AccessTools.Field(typeof(StartOfRound), nameof(StartOfRound.livingPlayers));
+            for (int i = 0; i < codes.Count; i++)
+            {
+                if (codes[i].opcode == OpCodes.Call)
+                {
+                    string methodName = codes[i].operand.ToString();
+                    if (methodName.Contains("FindObjectOfType") && methodName.Contains("VehicleController"))
+                    {
+                        codes[i].opcode = OpCodes.Ldsfld;
+                        codes[i].operand = AccessTools.Field(typeof(HarmonyPatches), nameof(vehicleController));
+                        Plugin.StaticLogger.LogDebug($"Use cached VehicleController in Kidnapper Fox AI");
+                    }
+                    else
+                    {
+                        MethodInfo methodInfo = codes[i].operand as MethodInfo;
+                        if (methodInfo == mathfMax && codes[i - 1].opcode == OpCodes.Ldc_I4_0 && codes[i - 4].opcode == OpCodes.Ldfld && (FieldInfo)codes[i - 4].operand == livingPlayers)
+                        {
+                            codes[i].operand = mathfClamp;
+                            codes.Insert(i, new(OpCodes.Ldc_I4_3));
+                            i++;
+                            Plugin.StaticLogger.LogDebug($"Clamp livingPlayers-1 between 0 and 3");
+                        }
+                    }
+                }
+            }
+
+            return codes;
         }
     }
 }


### PR DESCRIPTION
Adjust Kidnapper Fox behavior to better support lobby expansion mods (primarily, More Company):

1. Kidnapper foxes have varying confidence - they only retreat when all living players (minus one) are looking at it. (So a 4 player lobby needs 3 people to stare, but if only 1 or 2 players are alive, you only need 1 player to stare.)
   - **Before this PR**, a lobby with 50 surviving players would need 49 to stare at the fox. Even a lobby of 6 players would need 5, which is already pretty excessive.
   - **After this PR**, the fox's confidence will be limited to 3 players maximum. (So behavior is unchanged in normal 4 player games, this is just a concession for larger lobbies)
2. Kidnapper fox cycles through the player list a single player slot at a time, once per AI interval (0.2s) - so when determining if player 1 should be targeted, if they are not a valid target, the next 0.6s are spent checking players 2-4, and then player 1 is checked again after a 0.8s delay.
   - **Before this PR**, it could take as long as 10 seconds for player 1 to get checked again when playing with 50 player slots, even if all 46 of the additional slots are empty!
   - **After this PR**, empty player slots past the first 4 will be skipped immediately, to reduce "targeting lag" as much as possible within the current constraints of the fox's AI. The fox will still make targeting decisions slower when more than 4 players are connected, but this should still feel significantly snappier if your lobbies regularly have fewer connected players than total slots (More Company defaults to 32 slots, so this is a pretty likely scenario)